### PR TITLE
fix `job_type` url parameter

### DIFF
--- a/scripts/list_jobs.py
+++ b/scripts/list_jobs.py
@@ -37,7 +37,7 @@ def list_jobs(type):
     headers['User-Agent'] = "BatchCompliancePythonScript"
 
     #Injecting Job type into the request...
-    response = requests.get(f"{URL}?job_type={type}", auth=bearer_oauth, headers=headers)
+    response = requests.get(f"{URL}?type={type}", auth=bearer_oauth, headers=headers)
 
     if response.status_code != 200:
         print(f"Error requesting Job list: {response.status_code} | {response.text}")


### PR DESCRIPTION
`job_type` changed to `type` now

### Problem

Parameter `job_type` is the wrong one, throws

```
Error requesting Job list: 400 | {"errors":[{"parameters":{"type":[]},"message":"The `type` query parameter can not be empty"},{"parameters":{"job_type":["tweets"]},"message":"The query parameter [job_type] is not one of [type,status,compliance_job.fields]"}],"title":"Invalid Request","detail":"One or more parameters to your request was invalid.","type":"https://api.twitter.com/2/problems/invalid-request"}
```

### Solution

Rename parameter to `type` https://developer.twitter.com/en/docs/twitter-api/compliance/batch-compliance/api-reference/post-compliance-jobs

### Result

Worked after this change.
